### PR TITLE
fix: check buffer exists before applying changes

### DIFF
--- a/lua/lsp-format/init.lua
+++ b/lua/lsp-format/init.lua
@@ -164,6 +164,10 @@ M._handler = function(err, result, ctx)
         M._next()
         return
     end
+    if vim.fn.bufexists(ctx.bufnr) == 0 then
+        M._next()
+        return
+    end
     if not vim.api.nvim_buf_is_loaded(ctx.bufnr) then
         vim.fn.bufload(ctx.bufnr)
         vim.api.nvim_buf_set_var(ctx.bufnr, "format_changedtick", vim.api.nvim_buf_get_var(ctx.bufnr, "changedtick"))


### PR DESCRIPTION
This will fix problem:

```
Error executing vim.schedule lua callback: Vim:E158: Invalid buffer name: 1                                                                                              
stack traceback:                                                                                                                                                         
        [C]: in function 'bufload'                                                                                                                                       
        ...ack/packer/start/lsp-format.nvim/lua/lsp-format/init.lua:168: in function 'handler'                                                                           
        ...r/neovim/HEAD-db40701/share/nvim/runtime/lua/vim/lsp.lua:1388: in function ''                                                                                 
        vim/_editor.lua: in function <vim/_editor.lua:0>                                                                                                                 
```

Problem appears when renaming class and LSP automatically renames file too to match new class name.