### PR TITLE
Add /doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/doc/tags
 vendor


### PR DESCRIPTION
I manage my vim plugins using git submodules, and without this it adds noise to my git status after :helptags ALL.
