### PR TITLE
feat: add force_attach option to attach even though formatting unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ formatting.
 
 `force` will write the format result to the buffer, even if the buffer changed after the format request started.
 
+#### `force_attach` format option
+
+`force_attach` will attach lsp-format to the LSP client even if the latter does not seem to support formatting.
+
 ## Notes
 
 #### Make sure you remove any old format on save code

--- a/doc/format.txt
+++ b/doc/format.txt
@@ -106,6 +106,20 @@ force                                                       *lsp-format-force*
           }
       }
 
+------------------------------------------------------------------------------
+force_attach                                         *lsp-format-force_attach*
+
+  `force_attach` is a boolean flag. When on lsp-format will be attached to the
+  LSP client even if the latter does not seem to support formatting.
+
+  Example: >
+
+      require "lsp-format".setup {
+          typst = {
+              force_attach = true
+          }
+      }
+
 ==============================================================================
  4. COMMANDS                                             *lsp-format-commands*
 


### PR DESCRIPTION
Some language servers rely on dynamic registration for the `textDocument/formatting` capability.
Although the neovim `client.supports_method` (used [here](https://github.com/lukas-reineke/lsp-format.nvim/blob/3612642b0e2eb85015838df5dcfbacb61f15db98/lua/lsp-format/init.lua#L172)) is [supposed to account for that](https://github.com/neovim/neovim/blob/v0.10.0/runtime/doc/news.txt#L246-L250), some language servers are still not reporting to support this capability.

To account for this, this PR introduces a new parameter `force_attach` that lets the user skip the [`if not client.supports_method(method)` check](https://github.com/lukas-reineke/lsp-format.nvim/blob/3612642b0e2eb85015838df5dcfbacb61f15db98/lua/lsp-format/init.lua#L172) and attach lsp-format nonetheless.
This has been working for me for [tinymist](https://github.com/Myriad-Dreamin/tinymist). Formatting works great now.