### PR TITLE
Add non-deprecated setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,24 +46,17 @@ call plug#end()
 
 ## Setup
 
-To use LSP-format, you have to run the setup function, and pass the `on_attach` function to each LSP that should use it.
-
-```lua
-require("lsp-format").setup {}
-require("lspconfig").gopls.setup { on_attach = require("lsp-format").on_attach }
-```
-
-or
+To use LSP-format, you have to run the setup function, and register a `LspAttach` autocmd:
 
 ```lua
 require("lsp-format").setup {}
 
-local on_attach = function(client, bufnr)
-    require("lsp-format").on_attach(client, bufnr)
-
-    -- ... custom code ...
-end
-require("lspconfig").gopls.setup { on_attach = on_attach }
+vim.api.nvim_create_autocmd('LspAttach', {
+  callback = function(args)
+    local client = assert(vim.lsp.get_client_by_id(args.data.client_id))
+    require("lsp-format").on_attach(client, args.buf)
+  end,
+})
 ```
 
 That's it, saving a buffer will format it now.

--- a/doc/format.txt
+++ b/doc/format.txt
@@ -32,8 +32,17 @@ It does not
 ==============================================================================
  2. SETUP                                                   *lsp-format-setup*
 
-To use LSP-format, you have to run the setup function, and pass the `on_attach`
-function to each LSP that should use it.
+To use LSP-format, you have to run the setup function, and register a
+`LspAttach` autocmd: >
+
+    require("lsp-format").setup {}
+
+    vim.api.nvim_create_autocmd('LspAttach', {
+      callback = function(args)
+        local client = assert(vim.lsp.get_client_by_id(args.data.client_id))
+        require("lsp-format").on_attach(client, args.buf)
+      end,
+    })
 
 The setup functions takes one optional argument that maps |filetypes| to
 format options.


### PR DESCRIPTION
`lspconfig`'s `setup` methods are deprecated. IIUC, this is the modern alternative.

This completes https://github.com/lukas-reineke/lsp-format.nvim/issues/98