### PR TITLE
fix: fix deprecated `client.method()` calls for Neovim 0.12+

### DIFF
--- a/lua/lsp-format/init.lua
+++ b/lua/lsp-format/init.lua
@@ -254,7 +254,7 @@ end
 ---@param client vim.lsp.Client
 ---@param format_options table
 local format = function(bufnr, client, format_options)
-    if not client.supports_method(method, { bufnr = bufnr }) then
+    if not client:supports_method(method, bufnr) then
         log.warn(string.format('"%s" is not supported for %s, not formatting', method, client.name))
         return
     end
@@ -263,10 +263,10 @@ local format = function(bufnr, client, format_options)
     local timeout_ms = 2000
     if format_options.sync then
         ---@diagnostic disable-next-line
-        local result = client.request_sync(method, params, timeout_ms, bufnr) or {}
+        local result = client:request_sync(method, params, timeout_ms, bufnr) or {}
         handler(result.err, result.result, { client_id = client.id, bufnr = bufnr, params = params })
     else
-        client.request(method, params, handler, bufnr)
+        client:request(method, params, handler, bufnr)
     end
 end
 

--- a/specs/features/main_spec.lua
+++ b/specs/features/main_spec.lua
@@ -9,7 +9,7 @@ local mock_client = {
     name = "lsp-client-test",
     request = function(_, _, _, _) end,
     request_sync = function(_, _, _, _) end,
-    supports_method = function(_) end,
+    supports_method = function(_, _) end,
     setup = function() end,
 }
 
@@ -26,7 +26,7 @@ describe("lsp-format", function()
     before_each(function()
         c = mock(mock_client, true)
         api = mock(vim.api)
-        c.supports_method = function(_, _)
+        c.supports_method = function(_, _, _)
             return true
         end
         f.setup {}


### PR DESCRIPTION
Neovim 0.12 wrapped LSP client methods with a `method_wrapper` that detects dot-style calls and emits a deprecation warning:

```
client.supports_method is deprecated. Run ":checkhealth vim.deprecated" for more information
```

The dot-call form will be removed entirely in Neovim 0.13.
The colon syntax is also backward-compatible with older Neovim versions since the underlying functions already accepted `self` as the first argument.


This PR migrates those calls to the colon syntax (e.g. `client:supports_method()`).
It also updates test mocks to match the colon-call convention (accepting `self` as first parameter).
